### PR TITLE
style(FlexContainer): use flex-start instead of justify-between

### DIFF
--- a/src/styles/hangloose.module.css
+++ b/src/styles/hangloose.module.css
@@ -13,7 +13,7 @@
 .flexContainer {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-start;
 }
 
 .user {


### PR DESCRIPTION
<img width="1440" alt="Screenshot 2023-03-27 at 23 11 32" src="https://user-images.githubusercontent.com/57234795/228109187-04bc0adb-0b7b-4b47-8060-3c1762505093.png">
